### PR TITLE
New features to GArTPC

### DIFF
--- a/duneggd/Config/GArTPC.cfg
+++ b/duneggd/Config/GArTPC.cfg
@@ -4,10 +4,19 @@
 [GArTPC]
 class               = duneggd.SubDetector.GArTPC.GArTPCBuilder
 subbuilders         = []
-halfDimension       = {'dx':Q('6m'),'dy':Q('6m'),'dz':Q('6m')}
-tpcDimension       = {'dx':Q('175cm'),'dy':Q('225cm'),'dz':Q('125cm')}
-ChamberRadius       = Q('400cm')
-ChamberLength       = Q('500cm')
+halfDimension       = {'rmin':Q('0mm'),'rmax':Q('3251mm'),'dz':Q('3001mm')}
+tpcDimension        = {'dx':Q('450cm'),'dy':Q('350cm'),'dz':Q('250cm')}
+chamberDimension    = { 'r':Q('325cm'),'dz':Q('600cm') }
 BField              = '(0 T, 0 T, 0 T)'
-Material            = 'GAr'
-drift               = 'x'
+
+# Material definition:
+
+# Define by string
+#Material            = 'GAr'
+
+# Define by composition
+# 10 atm pure argon
+Material            = {'Ar':1}
+MaterialName        = 'HPGAr'
+Density             = '0.01784*g/cc'
+drift               = 'z'


### PR DESCRIPTION
Added a few new features to the GArTPC geometry:
- Can now create a custom gas using the config file
- Can now set the drift direction to x, y, or z (this sets the rotations of the TPC volumes within the main gas volume
- main logical volume is now a Tubs so that it can match the vacuum vessel geometry better. This will allow it to be placed into other volumes without problems with overlaps.

Plus some improvements to the code:
- construct_tpcs() now calls construct_tpc() for each TPC volume. This avoids code duplication and will make it easier to start adding in other structures like readout planes and field cages.