### PR TITLE
Updates to GArTPC & Other Modules

### DIFF
--- a/duneggd/Component/Plane.py
+++ b/duneggd/Component/Plane.py
@@ -44,7 +44,7 @@ class SBPlaneBuilder(gegede.builder.Builder):
         # Place the bars in the plane
         nScintBarsPerPlane = int(math.floor((self.SBPlaneDim[0]/self.ScintBarDim[0])))
         if self.nScintBars != nScintBarsPerPlane:
-           print 'SBPlaneBuilder: making'+str(nScintBarsPerPlane)+' scintillator bars per plane, should be '+str(self.nScintBars)
+           print( 'SBPlaneBuilder: making'+str(nScintBarsPerPlane)+' scintillator bars per plane, should be '+str(self.nScintBars))
   
         for i in range(nScintBarsPerPlane):
             xpos = -0.5*self.SBPlaneDim[0] + (i+0.5)*self.ScintBarDim[0]

--- a/duneggd/Component/RPCMod.py
+++ b/duneggd/Component/RPCMod.py
@@ -47,8 +47,8 @@ class RPCModBuilder(gegede.builder.Builder):
         nXStrips = int(self.resiplateDim[0]/self.stripxDim[0])
         nYStrips = int(self.resiplateDim[1]/self.stripyDim[1])
 
-        print 'RPCModBuilder: '+ str(nXStrips) +' X-Strips per RPC '
-        print 'RPCModBuilder: '+ str(nYStrips) +' Y-Strips per RPC '
+        print( 'RPCModBuilder: '+ str(nXStrips) +' X-Strips per RPC ')
+        print( 'RPCModBuilder: '+ str(nYStrips) +' Y-Strips per RPC ')
 
         # for loop to position and place X strips in RPCMod
         for i in range(nXStrips):
@@ -62,7 +62,7 @@ class RPCModBuilder(gegede.builder.Builder):
             pxS_in_m = geom.structure.Placement( 'placeXStrip-'+str(i)+'_in_'+self.name,
                                                  volume = rpcStripx_lv,pos = xS_in_m, rot = self.rotateEven) #,rot = "r90aboutX" )
             rpcMod_lv.placements.append( pxS_in_m.name )
-            #print str(i)+' x-strip pos: '+str(xpos)+str(ypos)+str(zpos)
+            #print( str(i)+' x-strip pos: '+str(xpos)+str(ypos)+str(zpos))
 
 
         # for loop to position and place Y strips in RPCMod
@@ -76,7 +76,7 @@ class RPCModBuilder(gegede.builder.Builder):
             pyS_in_m = geom.structure.Placement( 'placeYStrip-'+str(j)+'_in_'+self.name,
                                                  volume = rpcStripy_lv,pos = yS_in_m, rot = self.rotateEven )#,rot = "r90aboutX")
             rpcMod_lv.placements.append( pyS_in_m.name )
-            #print str(j)+' y-strip pos: '+str(xpos)+str(ypos)+str(zpos)
+            #print( str(j)+' y-strip pos: '+str(xpos)+str(ypos)+str(zpos))
 
 
         for k in range(2):

--- a/duneggd/Component/RPCTray.py
+++ b/duneggd/Component/RPCTray.py
@@ -21,7 +21,7 @@ class RPCTrayBuilder(gegede.builder.Builder):
       self.nrpcRow = compNrpcRow 
       self.compRotation = compRotation
 
-      #print self.builders
+      #print( self.builders)
       self.RPCModBldr = self.get_builder('RPCMod')
 
     #^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^
@@ -63,7 +63,7 @@ class RPCTrayBuilder(gegede.builder.Builder):
                 prpcm_in_t = geom.structure.Placement( 'placeRPCMod-'+str(self.nrpcCol*i+j)+'_in_'+self.name,
                                                        volume = rpcMod_lv, pos = rpcm_in_t, rot = self.compRotation)
                 rpcTray_lv.placements.append( prpcm_in_t.name )
-                #print 'rpctray : '+str(i)+' '+str(j)+' RPCTray- xpos: '+str(xpos)+' ypos: '+str(ypos)+' zpos: '+str(zpos)
+                #print( 'rpctray : '+str(i)+' '+str(j)+' RPCTray- xpos: '+str(xpos)+' ypos: '+str(ypos)+' zpos: '+str(zpos))
         
         
         return

--- a/duneggd/Component/RPCTrayRot.py
+++ b/duneggd/Component/RPCTrayRot.py
@@ -22,7 +22,7 @@ class RPCTrayRotBuilder(gegede.builder.Builder):
       self.compRotation = compRotation
       self.compExtend  = compExtend
 
-      #print self.builders
+      #print( self.builders)
       self.RPCModBldr = self.get_builder('RPCMod')
       return
 
@@ -65,7 +65,7 @@ class RPCTrayRotBuilder(gegede.builder.Builder):
                 prpcm_in_t = geom.structure.Placement( 'placeRPCMod-'+str(self.nrpcCol*i+j)+'_in_'+self.name,
                                                        volume = rpcMod_lv, pos = rpcm_in_t, rot = self.compRotation)
                 rpcTray_lv.placements.append( prpcm_in_t.name )
-                #print 'rpctray : '+str(i)+' '+str(j)+' RPCTray- xpos: '+str(xpos)+' ypos: '+str(ypos)+' zpos: '+str(zpos)
+                #print( 'rpctray : '+str(i)+' '+str(j)+' RPCTray- xpos: '+str(xpos)+' ypos: '+str(ypos)+' zpos: '+str(zpos))
         
         
         return

--- a/duneggd/Component/STTModule.py
+++ b/duneggd/Component/STTModule.py
@@ -29,13 +29,13 @@ class STTModuleBuilder(gegede.builder.Builder):
     def construct( self, geom ):
         # main volume
         main_lv, main_hDim = ltools.main_lv( self, geom, "Box")
-        print "STTModule::construct()"
-        print "  main_lv = ", main_lv.name
+        print( "STTModule::construct()")
+        print( "  main_lv = ", main_lv.name)
         self.add_volume( main_lv )
 
         # Straw Plane 1
         plane1_builder=self.get_builder("STTPlane1")
-        print "plane1_builder=",plane1_builder
+        print( "plane1_builder=",plane1_builder)
         plane1_lv=plane1_builder.get_volume()
         plane1_pos=geom.structure.Position(self.name+'_Plane1_pos',
                                            self.centerPlane1[0],self.centerPlane1[1],self.centerPlane1[2])
@@ -47,7 +47,7 @@ class STTModuleBuilder(gegede.builder.Builder):
 
         # Straw Plane 2
         plane2_builder=self.get_builder("STTPlane2")
-        print "plane2_builder=",plane2_builder
+        print( "plane2_builder=",plane2_builder)
         plane2_lv=plane2_builder.get_volume()
         plane2_pos=geom.structure.Position(self.name+'_Plane2_pos',
                                            self.centerPlane2[0],self.centerPlane2[1],self.centerPlane2[2])

--- a/duneggd/Component/STTModule.py
+++ b/duneggd/Component/STTModule.py
@@ -30,12 +30,12 @@ class STTModuleBuilder(gegede.builder.Builder):
         # main volume
         main_lv, main_hDim = ltools.main_lv( self, geom, "Box")
         print( "STTModule::construct()")
-        print( "  main_lv = ", main_lv.name)
+        print( "  main_lv = "+ main_lv.name)
         self.add_volume( main_lv )
 
         # Straw Plane 1
         plane1_builder=self.get_builder("STTPlane1")
-        print( "plane1_builder=",plane1_builder)
+        print( "plane1_builder="+str(plane1_builder))
         plane1_lv=plane1_builder.get_volume()
         plane1_pos=geom.structure.Position(self.name+'_Plane1_pos',
                                            self.centerPlane1[0],self.centerPlane1[1],self.centerPlane1[2])
@@ -47,7 +47,7 @@ class STTModuleBuilder(gegede.builder.Builder):
 
         # Straw Plane 2
         plane2_builder=self.get_builder("STTPlane2")
-        print( "plane2_builder=",plane2_builder)
+        print( "plane2_builder="+str(plane2_builder))
         plane2_lv=plane2_builder.get_volume()
         plane2_pos=geom.structure.Position(self.name+'_Plane2_pos',
                                            self.centerPlane2[0],self.centerPlane2[1],self.centerPlane2[2])

--- a/duneggd/Component/STTPlane.py
+++ b/duneggd/Component/STTPlane.py
@@ -35,7 +35,7 @@ class STTPlaneBuilder(gegede.builder.Builder):
 
             # initial position, particular case
             pos = [-main_hDim[0]+sb_dim[0]*0.5, Q('0m'), Q('0m')]
-            print( "STTPlane sb_dim[]= ",sb_dim)
+            print( "STTPlane sb_dim[]= "+str(sb_dim))
             for elem in range(self.NElements):
                 pos = [ sb_dim[0]*0.5+pos[0], pos[1]-math.pow(-1,elem+1)*sb_dim[0]*math.sqrt(3)*0.5, pos[2] ]
                 sb_pos = geom.structure.Position(self.name+sb_lv.name+str(elem)+'_pos',

--- a/duneggd/Component/STTPlane.py
+++ b/duneggd/Component/STTPlane.py
@@ -35,7 +35,7 @@ class STTPlaneBuilder(gegede.builder.Builder):
 
             # initial position, particular case
             pos = [-main_hDim[0]+sb_dim[0]*0.5, Q('0m'), Q('0m')]
-            print "STTPlane sb_dim[]= ",sb_dim
+            print( "STTPlane sb_dim[]= ",sb_dim)
             for elem in range(self.NElements):
                 pos = [ sb_dim[0]*0.5+pos[0], pos[1]-math.pow(-1,elem+1)*sb_dim[0]*math.sqrt(3)*0.5, pos[2] ]
                 sb_pos = geom.structure.Position(self.name+sb_lv.name+str(elem)+'_pos',

--- a/duneggd/Component/SingleArrangePlane.py
+++ b/duneggd/Component/SingleArrangePlane.py
@@ -26,4 +26,4 @@ class SingleArrangePlaneBuilder(gegede.builder.Builder):
                 TranspV = self.TranspV
             ltools.placeBuilders( self, geom, main_lv, TranspV )
         else:
-            print( "**Warning, no Elements to place inside ", self.name)
+            print( "**Warning, no Elements to place inside "+ self.name)

--- a/duneggd/Component/SingleArrangePlane.py
+++ b/duneggd/Component/SingleArrangePlane.py
@@ -26,4 +26,4 @@ class SingleArrangePlaneBuilder(gegede.builder.Builder):
                 TranspV = self.TranspV
             ltools.placeBuilders( self, geom, main_lv, TranspV )
         else:
-            print "**Warning, no Elements to place inside ", self.name
+            print( "**Warning, no Elements to place inside ", self.name)

--- a/duneggd/Config/GARTPCggd.cfg
+++ b/duneggd/Config/GARTPCggd.cfg
@@ -1,12 +1,18 @@
-# This just builds a GArTPC as a primary detector for standalone testing
+# Create the GArTPC as a standalone primary detector
+#
+#  gegede-cli duneggd/Config/GARTPCggd.cfg duneggd/Config/GArTPC.cfg \
+#             duneggd/Config/DETENCLOSURE-prim-only.cfg \
+#             duneggd/Config/WORLDggd.cfg -w World -o gartpc.gdml
+#
+
 [Primary]
 class               = duneggd.Det.Primary.PrimaryBuilder
 subbuilders         = ['GArTPC']
 halfDimension       = {'dx':Q('8m'),'dy':Q('8m'),'dz':Q('10m')}
 Material            = 'Air'
 InsideGap           = [ Q('10cm') ]
-Positions	    = [	[ Q("0m"), Q("0m"), Q("6.5m") ],
+Positions	    = [	[ Q("0m"), Q("0m"), Q("0m") ],
 		      	[ Q("0m"), Q("0m"), Q("0m") ] ]
 
-Rotations	    = [	[ Q("0deg"), Q("0deg"), Q("0deg") ],
+Rotations	    = [	[ Q("0deg"), Q("90deg"), Q("0deg") ],
 		      	[ Q("0deg"), Q("0deg"), Q("0deg") ] ]

--- a/duneggd/Config/GArTPC.cfg
+++ b/duneggd/Config/GArTPC.cfg
@@ -12,11 +12,28 @@ BField              = '(0 T, 0 T, 0 T)'
 # Material definition:
 
 # Define by string
-#Material            = 'GAr'
+Material            = 'HP_ArCO2'
 
 # Define by composition
+
+# Available gases include:
+#   ** Gases labeled by chemical formula
+#   ** except where label marked with a *
+# Ar (argon)
+# CH4 (*Methane)
+# CH2F2 (difluoromethane)
+# CF4 (tetrafluoromethane)
+# C2H6 (*Ethane)
+# CH3OCH3 (*DME - dimethyl ether)
+# C3H8 (propane)
+# C4H10 ([iso]butane)
+# CO2 (Carbon dioxide)
+# N2 (*Nitrogen)
+# SF6 (sulfur hexafluoride)
+
 # 10 atm pure argon
-Material            = {'Ar':1}
-MaterialName        = 'HPGAr'
-Density             = '0.01784*g/cc'
+#Material            = {'Ar':1}
+#MaterialName        = 'HPGAr'
+#Density             = '0.01784*g/cc'
+
 drift               = 'z'

--- a/duneggd/Det/Secondary.py
+++ b/duneggd/Det/Secondary.py
@@ -80,11 +80,11 @@ class SecondaryBuilder(gegede.builder.Builder):
         # first check to see if ecal barrel fits in magnet, otherwise nudge it to fit
         # need to do this before using and magnet dimensions for positioning
         if( self.magInDim[1] < ecalBarDim[1] ):
-             print "DetectorBuilder: Barrel ECAL ("+str(ecalBarDim[1])+" high) does not fit inside magnet ("+str(self.magInDim[1])+")"
+             print( "DetectorBuilder: Barrel ECAL ("+str(ecalBarDim[1])+" high) does not fit inside magnet ("+str(self.magInDim[1])+")")
              self.magInDim[1]  = ecalBarDim[1]
              self.magOutDim[1] = self.magInDim[1] + 2*self.magThickness
-             print "       ... nudging magnet inner and outer height dimensions to "+str(self.magInDim[1])+" and "+str(self.magOutDim[1])
-             print "       ... this affects PRC placements, which fit tightly around magnet"
+             print( "       ... nudging magnet inner and outer height dimensions to "+str(self.magInDim[1])+" and "+str(self.magOutDim[1]))
+             print( "       ... this affects PRC placements, which fit tightly around magnet")
 
         # vol is a bounding box ~ not corresponding to physical volume.
         #  assume Barrel biggest in x and y
@@ -144,45 +144,45 @@ class SecondaryBuilder(gegede.builder.Builder):
        ########################### Check Assumptions ###########################
         
         if( muidDownDim[2] == muidUpDim[2] ):
-            print "DetectorBuilder: Up and Downstream MuIDs the same thickness in beam direction"
+            print( "DetectorBuilder: Up and Downstream MuIDs the same thickness in beam direction")
 
         # For the Boolean shapes, make sure the inner/outer dimensions match 
         #  where they should -- barrel is a "tube" in z and magnet a "tube" in x
         if( muidBarInDim[2] != muidBarOutDim[2] ):
-            print "DetectorBuilder: MuID barrel not same length in z on inside and outside"
-            print "     inner barrel is "+str(muidBarInDim[2])+" and outer barrel is "+str(muidBarOutDim[2])+" in z"
+            print( "DetectorBuilder: MuID barrel not same length in z on inside and outside")
+            print( "     inner barrel is "+str(muidBarInDim[2])+" and outer barrel is "+str(muidBarOutDim[2])+" in z")
         if( self.magInDim[0] != self.magOutDim[0] ):
-            print "DetectorBuilder: Magnet not same length in x on inside and outside"
-            print "     inner magnet is "+str(self.magInDim[0])+" and outer magnet is "+str(self.magOutDim[0])+" in x"
+            print( "DetectorBuilder: Magnet not same length in x on inside and outside")
+            print( "     inner magnet is "+str(self.magInDim[0])+" and outer magnet is "+str(self.magOutDim[0])+" in x")
 
         # The MuID barrel should tightly hug the magnet,
         #   and be the same dimension in z
         if( muidBarInDim[0] != self.magOutDim[0] ):
-            print "DetectorBuilder: MuID barrel not touching magnet in x"
-            print "     inner barrel is "+str(muidBarInDim[0])+" and magnet is "+str(self.magOutDim[0])+" in x"
+            print( "DetectorBuilder: MuID barrel not touching magnet in x")
+            print( "     inner barrel is "+str(muidBarInDim[0])+" and magnet is "+str(self.magOutDim[0])+" in x")
         if( muidBarInDim[1] != self.magOutDim[1] ):
-            print "DetectorBuilder: MuID barrel not touching magnet in y"
-            print "     inner barrel is "+str(muidBarInDim[1])+" and outer magnet is "+str(self.magOutDim[1])+" in y"
+            print( "DetectorBuilder: MuID barrel not touching magnet in y")
+            print( "     inner barrel is "+str(muidBarInDim[1])+" and outer magnet is "+str(self.magOutDim[1])+" in y")
         if( muidBarInDim[2] != self.magOutDim[2] ):
-            print "DetectorBuilder: MuID barrel not same length in z as magnet"
-            print "     barrel is "+str(muidBarInDim[2])+" and outer magnet is "+str(self.magOutDim[2])+" in z"
+            print( "DetectorBuilder: MuID barrel not same length in z as magnet")
+            print( "     barrel is "+str(muidBarInDim[2])+" and outer magnet is "+str(self.magOutDim[2])+" in z")
 
         # Check that the ECAL, positioned tightly around the STT, fits
         #   inside the inner dimensions of the magnet.
         if( (ecalUpPos[2] - 0.5*ecalUpDim[2]) < (magPos[2] - 0.5*self.magInDim[2]) ):
-            print "DetectorBuilder: Upstream ECAL upstream z face ("+str(ecalUpPos[2] - 0.5*ecalUpDim[2])+") overlaps magnet ("+str(magPos[2] - 0.5*self.magInDim[2])+")"
-            print "      ... downstream ECAL downstream face is "+str(magPos[2] + 0.5*self.magInDim[2] - (ecalDownPos[2] + 0.5*ecalDownDim[2]))+" away from magnet"
+            print( "DetectorBuilder: Upstream ECAL upstream z face ("+str(ecalUpPos[2] - 0.5*ecalUpDim[2])+") overlaps magnet ("+str(magPos[2] - 0.5*self.magInDim[2])+")")
+            print( "      ... downstream ECAL downstream face is "+str(magPos[2] + 0.5*self.magInDim[2] - (ecalDownPos[2] + 0.5*ecalDownDim[2]))+" away from magnet")
         if( (ecalDownPos[2] + 0.5*ecalDownDim[2]) > (magPos[2] + 0.5*self.magInDim[2]) ):
-            print "DetectorBuilder: Downstream ECAL downstream z face ("+str(ecalDownPos[2] + 0.5*ecalDownDim[2])+") overlaps magnet ("+str(magPos[2] + 0.5*self.magInDim[2])+")"
-            print "      ... upstream ECAL upstream face is "+str(ecalUpPos[2] - 0.5*ecalUpDim[2] - (magPos[2] - 0.5*self.magInDim[2]))+" away from magnet"
+            print( "DetectorBuilder: Downstream ECAL downstream z face ("+str(ecalDownPos[2] + 0.5*ecalDownDim[2])+") overlaps magnet ("+str(magPos[2] + 0.5*self.magInDim[2])+")")
+            print( "      ... upstream ECAL upstream face is "+str(ecalUpPos[2] - 0.5*ecalUpDim[2] - (magPos[2] - 0.5*self.magInDim[2]))+" away from magnet")
         if( self.magInDim[2] < ecalUpDim[2] + sttDim[2] + ecalDownDim[2] ):
-            print "DetectorBuilder: STT+ECAL ends ("+str(ecalUpDim[2] + sttDim[2] + ecalDownDim[2])+") do not fit inside magnet ("+str(self.magInDim[2])+")"
+            print( "DetectorBuilder: STT+ECAL ends ("+str(ecalUpDim[2] + sttDim[2] + ecalDownDim[2])+") do not fit inside magnet ("+str(self.magInDim[2])+")")
  
         if(       muidDownDim[1] > muidBarDim[1] 
                or muidDownDim[2] > muidBarDim[2]
                or muidUpDim[1]   > muidBarDim[1]
                or muidUpDim[2]   > muidBarDim[2]  ):
-            print "DetectorBuilder: MuID Ends have larger xy dimensions than Barrel"
+            print( "DetectorBuilder: MuID Ends have larger xy dimensions than Barrel")
 
         ############################ Finish Checking ############################
         #########################################################################

--- a/duneggd/LocalTools/localtools.py
+++ b/duneggd/LocalTools/localtools.py
@@ -37,7 +37,7 @@ def addAuxParams( slf, ggd_vol ):
 
     assert( slf.AuxParams != None ), " No AuxParams defined on %s " % ggd_vol.name
 
-    for key in slf.AuxParams.keys():
+    for key in slf.AuxParams:
         if isinstance(slf.AuxParams[key],str):
             ggd_vol.params.append((key,slf.AuxParams[key]))
 

--- a/duneggd/LocalTools/localtools.py
+++ b/duneggd/LocalTools/localtools.py
@@ -1,5 +1,6 @@
 from gegede import Quantity as Q
 import math
+from platform import python_version
 
 #^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^
 def main_lv( slf, geom, shape):
@@ -33,10 +34,12 @@ def main_lv( slf, geom, shape):
 
 #^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^
 def addAuxParams( slf, ggd_vol ):
+
     assert( slf.AuxParams != None ), " No AuxParams defined on %s " % ggd_vol.name
-    for key, value in slf.AuxParams.iteritems():
-        if isinstance(value,str):
-            ggd_vol.params.append((key,value))
+
+    for key in slf.AuxParams.keys():
+        if isinstance(slf.AuxParams[key],str):
+            ggd_vol.params.append((key,slf.AuxParams[key]))
 
 #^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^
 def getShapeDimensions( ggd_vol, geom ):

--- a/duneggd/LocalTools/materialdefinition.py
+++ b/duneggd/LocalTools/materialdefinition.py
@@ -263,3 +263,41 @@ def define_materials( g ):
                                     ("Scintillator", 0.48),
                                     ("epoxy_resin",0.10)
                             ))
+
+    # Materials for Gas TPC construction
+
+    # Quench gases not otherwise defined
+    cf4 = g.matter.Molecule('CF4',density='0.00372*g/cc',
+                            elements=(('carbon',1),('fluorine',4)) )
+
+    methane = g.matter.Molecule('Methane',density='0.000676*g/cc',
+                            elements=(('carbon',1),('hydrogen',4)) )
+
+
+    # For Gas TPC field cage & central electrode
+    # Polyvinyl fluoride (Tedlar)
+    pvf = g.matter.Molecule("PVF",density="1.71*g/cc",
+                            elements=(("carbon",2),("hydrogen",3),
+                                      ("fluorine",1)) )
+
+    kevlar = g.matter.Molecule("Kevlar",density="1.45*g/cc",
+                               elements=(("carbon",7),("hydrogen",5),
+                                         ("nitrogen",1),("oxygen",1)) 
+                              )
+
+    nomex_honeycomb = g.matter.Molecule("NomexHoneycomb",
+                                        density="0.029*g/cc",
+                                        elements=(
+                                               ("carbon",7),
+                                               ("hydrogen",5),
+                                               ("nitrogen",1),
+                                               ("oxygen",1)) )
+
+    mylar = g.matter.Molecule('Mylar',density="1.39*g/cc",
+                              elements=(('carbon',10),
+                                        ('hydrogen',8),
+                                        ('oxygen',4)))
+    # 60% kevlar, 40% epoxy resin
+    kevlar_prepreg = g.matter.Mixture("KevlarPrepreg",density="1.37*g/cc",
+                                      components=(("Kevlar",0.6),
+                                                  ("epoxy_resin",0.4)) )

--- a/duneggd/LocalTools/materialdefinition.py
+++ b/duneggd/LocalTools/materialdefinition.py
@@ -1,7 +1,7 @@
 # based on Tyler https://github.com/tyleralion/duneggd
 #^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^
 def define_materials( g ):
-    h  = g.matter.Element("hydrogen",   "H",  1,  "1.0791*g/mole" )
+    h  = g.matter.Element("hydrogen",   "H",  1,  "1.00791*g/mole" )
     b  = g.matter.Element("boron",      "B",  5,  "10.811*g/mole" )
     c  = g.matter.Element("carbon",     "C",  6,  "12.0107*g/mole")
     n  = g.matter.Element("nitrogen",   "N",  7,  "14.0671*g/mole")
@@ -266,14 +266,6 @@ def define_materials( g ):
 
     # Materials for Gas TPC construction
 
-    # Quench gases not otherwise defined
-    cf4 = g.matter.Molecule('CF4',density='0.00372*g/cc',
-                            elements=(('carbon',1),('fluorine',4)) )
-
-    methane = g.matter.Molecule('Methane',density='0.000676*g/cc',
-                            elements=(('carbon',1),('hydrogen',4)) )
-
-
     # For Gas TPC field cage & central electrode
     # Polyvinyl fluoride (Tedlar)
     pvf = g.matter.Molecule("PVF",density="1.71*g/cc",
@@ -301,3 +293,85 @@ def define_materials( g ):
     kevlar_prepreg = g.matter.Mixture("KevlarPrepreg",density="1.37*g/cc",
                                       components=(("Kevlar",0.6),
                                                   ("epoxy_resin",0.4)) )
+
+
+    methane  = g.matter.Molecule('Methane',
+                                 density='0.000716*g/cc',
+                                 elements=(
+                                    ('carbon',1),
+                                    ('hydrogen',4)))
+
+    ethane  = g.matter.Molecule('Ethane',
+                                density='0.00134*g/cc',
+                                elements=(
+                                    ('carbon',2),
+                                    ('hydrogen',6)))
+
+#    Propane defined as C3H8 
+#    propane  = g.matter.Molecule('Propane',
+#                                 density='0.00197*g/cc',
+#                                 elements=(
+#                                    ('carbon',3),
+#                                    ('hydrogen',8)))
+
+#    Isobutane defined as C4H10
+#    isobutane  = g.matter.Molecule('Isobutane',
+#                                   density='0.00260*g/cc',
+#                                   elements=(
+#                                      ('carbon',4),
+#                                      ('hydrogen',10)))
+
+#   SF6 already defined
+
+    # Tetrafluoromethane
+    cf4  = g.matter.Molecule('CF4',
+                             density='0.00393*g/cc',
+                             elements=(
+                                    ('carbon',1),
+                                    ('fluorine',4)))
+
+    # Difluoromethane 
+    ch2f2  = g.matter.Molecule('CH2F2',
+                               density='0.00232*g/cc',
+                               elements=(
+                                    ('carbon',1),
+                                    ('hydrogen',2),
+                                    ('fluorine',2)))
+
+    # Dimethyl ether
+    dme  = g.matter.Molecule('DME',
+                               density='0.00206*g/cc',
+                               elements=(
+                                    ('carbon',2),
+                                    ('hydrogen',6),
+                                    ('oxygen',1)))
+
+    n2 = g.matter.Molecule('Nitrogen',
+                           density='0.000625*g/cc',
+                           elements=(('nitrogen',1),))
+                                    
+  
+    # All at 10 atm
+    # Mixes are 9 atm Ar, 1 atm quencher   
+    hp_ar    = g.matter.Molecule('HP_Ar',
+                                 density='0.01784*g/cc',
+                                 elements=(('argon',1),))
+
+    hp_arco2 = g.matter.Mixture("HP_ArCO2",
+                                density='0.01802*g/cc',
+                                components=(
+                                    ('HP_Ar',0.890),
+                                    ('CO2',0.110)))
+
+    # P10
+    hp_arch4 = g.matter.Mixture('HP_ArCH4',
+                                density='0.01677*g/cc',
+                                components=(
+                                ('HP_Ar',0.957),
+                                ('Methane',0.043)))
+
+    hp_arcf4 = g.matter.Mixture('HP_ArCF4',
+                                density='0.01998*g/cc',
+                                components=(('HP_Ar',0.801),
+                                ('CF4',0.199)))
+

--- a/duneggd/SubDetector/ComplexSubDetector.py
+++ b/duneggd/SubDetector/ComplexSubDetector.py
@@ -30,4 +30,4 @@ class ComplexSubDetectorBuilder(gegede.builder.Builder):
                 TranspV = self.TranspV
             ltools.placeComplexBuilders( self, geom, main_lv, TranspV )
         else:
-            print( "**Warning, no Elements to place inside ", self.name)
+            print( "**Warning, no Elements to place inside "+ self.name)

--- a/duneggd/SubDetector/ComplexSubDetector.py
+++ b/duneggd/SubDetector/ComplexSubDetector.py
@@ -30,4 +30,4 @@ class ComplexSubDetectorBuilder(gegede.builder.Builder):
                 TranspV = self.TranspV
             ltools.placeComplexBuilders( self, geom, main_lv, TranspV )
         else:
-            print "**Warning, no Elements to place inside ", self.name
+            print( "**Warning, no Elements to place inside ", self.name)

--- a/duneggd/SubDetector/ECALMod.py
+++ b/duneggd/SubDetector/ECALMod.py
@@ -92,6 +92,6 @@ class ECALModBuilder(gegede.builder.Builder):
                 ecalMod_lv.placements.append( prsbp_in_ecalend.name )
                 n2=n2+1
                 
-        print( 'ECALModBuilder:',i+1 ,'SBPlanes', 'in '+str(self.name))
-        print( n1, 'SBPlanes have scint. bars oriented along X direction and', n2, 'SBPlanes have scint. bars oriented along Y direction for '+str(self.name) )
+        print( 'ECALModBuilder: '+str(i+1) +' SBPlanes in '+str(self.name))
+        print( str(n1)+ ' SBPlanes have scint. bars oriented along X direction and '+ n2+ ' SBPlanes have scint. bars oriented along Y direction for '+str(self.name) )
         return

--- a/duneggd/SubDetector/ECALMod.py
+++ b/duneggd/SubDetector/ECALMod.py
@@ -54,7 +54,7 @@ class ECALModBuilder(gegede.builder.Builder):
         # Calculate ECAL dimensions 
         self.ecalModDim    = list(SBPlaneDim) # get the right x and y dimension
         self.ecalModDim[2] = self.nSBPlanes*(self.leadThickness + SBPlaneDim[2])
-        print 'ECALModBuilder: set ECAL z dimension to '+str(self.ecalModDim[2])+' (configured as '+str(self.ecalThickness)+')'
+        print( 'ECALModBuilder: set ECAL z dimension to '+str(self.ecalModDim[2])+' (configured as '+str(self.ecalThickness)+')')
       
         # Make main shape/volume for this builder
         ecalModBox = geom.shapes.Box( self.name,
@@ -92,6 +92,6 @@ class ECALModBuilder(gegede.builder.Builder):
                 ecalMod_lv.placements.append( prsbp_in_ecalend.name )
                 n2=n2+1
                 
-        print 'ECALModBuilder:',i+1 ,'SBPlanes', 'in '+str(self.name)
-        print n1, 'SBPlanes have scint. bars oriented along X direction and', n2, 'SBPlanes have scint. bars oriented along Y direction for '+str(self.name) 
+        print( 'ECALModBuilder:',i+1 ,'SBPlanes', 'in '+str(self.name))
+        print( n1, 'SBPlanes have scint. bars oriented along X direction and', n2, 'SBPlanes have scint. bars oriented along Y direction for '+str(self.name) )
         return

--- a/duneggd/SubDetector/GArTPC.py
+++ b/duneggd/SubDetector/GArTPC.py
@@ -1,6 +1,17 @@
-"""
+""" GArTPC.py
+
 A basic builder for a gas TPC consisting of a cylindrical chamber 
 with two back-to-back rectangular active volmes.
+
+TO DO:
+
+Start splitting the various volumes into separate builders or 
+use equivalent existing builders whenever possible.
+
+Validate that rotations for x and y drift are in the correct
+direction.
+
+Add in electric field?
 
 """
 
@@ -10,10 +21,67 @@ from gegede import Quantity as Q
 
 
 class GArTPCBuilder(gegede.builder.Builder):
-    """ Build the Gas TPC volume. """
+    """ Class to build a gaseous argon TPC geometry.
+
+    Attributes:
+        ChamberRadius: Outer radius of the vacuum vessel.
+        ChamberLength: Full length of the vacuum vessel.
+        EndCapThickness: Thickness of the flat ends of the vessel.
+        WallThickness: Thickness of the rounded wall of the vessel.
+        ChamberMaterial: Material used to build the vacuum vessel.
+        BField: Magnetic field in the volume.
+        Material: Name of gas material.
+        GasDensity: Density of gas (only used for custom gas mixes).
+        Composition: Composition of a custom gas mixture.
+        halfDimension: Dimensions of volume holding the TPC geometry.
+        tpcDimension: Dimensions of each rectangular TPC volume.
+        HalfX: Half length of TPC in x-direction
+        HalfY: Half length of TPC in y-direction
+        HalfZ: Half of drift distance.
+        Drift: Drift axis
+        TPCGap: Half of spacing between TPCs. Reset when central 
+                electrode is created.
+        SmallGap: A small distance to help prevent overlaps
+        PadThickness: Thickness of PCB holding readout pads
+        PadMaterial: Material of PCB holding readout pads
+        PadOffset: Offset from TPC active volume (due to wire grids)
+        PadFrameThickness: Thickness of support structure behind PCB
+        PadFrameMaterial: Material of support structure.
+        CentElectrodeHCThickness: Thickness of honeycomb or similar
+                structure separating two electrode sheets
+        CentElectrodeThickness: Thickness of mylar (or similar)
+                sheet used to make the central electrode
+
+    """
 
     def configure(self,chamberDimension,tpcDimension,
                   halfDimension,Material,bfield=None,drift='z',**kwargs):
+
+        """ Set the configuration for the geometry.
+
+            The keywords MaterialName and Density should only be used
+            if Material is a dict-type rather than a string.
+
+            Args:
+                chamberDimension: Outer dimensions of vauum vessel.
+                    Dict. with keys 'r' and 'dz'
+                tpcDimension: Dimensions of each TPC.
+                    Dict with keys 'dx','dy','dz'
+                halfDimension: Half-dimensions of bounding volume.
+                    Dict with keys 'r' and 'dz' (dz=half of length)
+                Material: Gas material. String if using a standard
+                    material, dict in the form {material:mass_fraction,...}
+                bfield: Magnetic field (3D array-like). Don't use if a
+                    magnetic field was set in a parent volume.
+                drift: The drift direction. (x, y, or z)
+                kwargs: Additional keyword arguments. Allowed are:
+                    EndCapThickness, WallThickness, 
+                    ChamberMaterial, MaterialName, Density,
+                    PadThickness, PadMaterial, PadOffset,
+                    PadFrameThickness,PadFrameMaterial
+                    CentElectrodeHCThickness,        
+                    CentElectrodeThickness
+        """
 
         # The vacuum chamber is a G4Tubs for now
         self.ChamberRadius = chamberDimension['r']
@@ -59,8 +127,11 @@ class GArTPCBuilder(gegede.builder.Builder):
         self.HalfZ = tpcDimension['dz']/2
         self.Drift = drift
         # A bit of space for the central electrode
+
         self.TPCGap = Q('2mm') 
         self.SmallGap = Q('0.001mm')
+        self.CentElectrodeHCThickness = Q('6mm')
+        self.CentElectrodeThickness = Q('0.02mm')
 
         # Readout Pad Stuff
 
@@ -80,8 +151,27 @@ class GArTPCBuilder(gegede.builder.Builder):
             self.PadFrameMaterial = kwargs['PadFrameMaterial']
         if 'PadOffset' in kwargs.keys():
             self.PadOffset = kwargs['PadOffset']
+        if 'CentElectrodeHCThickness' in kwargs.keys():
+            self.CentElectrodeHCThickness = \
+                 kwargs['CentElectrodeHCThickness']
+        if 'CentElectrodeThickness' in kwargs.keys():
+            self.CentElectrodeThickness = \
+                 kwargs['CentElectrodeThickness']
+
 
     def construct(self,geom):
+        """ Construct the geometry.
+
+        The standard geometry consists of a cylindrical vessel 
+        filled with gas. Two TPC sensitive volumes are placed
+        within the gas, as is a central electrode.
+        After that, a readout plane and field cage are added 
+        to each TPC.
+
+        args:
+            geom: The geometry
+
+        """
 
         # If using a custom gas, define here
         if self.Composition is not None:
@@ -136,7 +226,15 @@ class GArTPCBuilder(gegede.builder.Builder):
         
 
     def construct_tpcs(self,geom,lv):
+        """ Construct the two TPCs along with their 
+        field cages and readout plaen
 
+        args:
+            geom: The geometry:
+            tpc_gas_lv: The vessel gas volume where
+                want to place the TPCs
+
+        """
 
         pos1 = []
         pos2 = []
@@ -168,10 +266,30 @@ class GArTPCBuilder(gegede.builder.Builder):
         self.construct_tpc(geom,"TPC2",pos2,rot2,lv)
 
     def construct_central_electrode(self,geom,rot,lv):
+        """ Create the central electrode
+
+        Currently is similar to the ALICE design.
+        The electrode consists of two thin layers
+        of mylar with a thicker layer of a honeycomb
+        structure to support things without providing
+        much material.
+
+        Implemented as two nested boxes.
+
+        Args:
+            geom: The geometry
+            rot: A 3D array giving the rotation
+            lv: The logical volume where we want to
+                place the electrode.
+
+        """
         
+
         # Create the shape and logical volume
-        cent_hc_dx = Q('6mm')
-        cent_my_dx = Q('0.02mm')
+        
+        cent_hc_dx = self.CentElectrodeHCThickness
+        cent_my_dx = self.CentElectrodeThickness
+
         cent_elec_shape = geom.shapes.Box('cent_elec_shape',
                                           self.HalfX,
                                           self.HalfY,
@@ -209,7 +327,20 @@ class GArTPCBuilder(gegede.builder.Builder):
         self.TPCGap = cent_hc_dx/2+cent_my_dx+self.SmallGap
 
     def construct_tpc(self,geom,name,pos_vec,rot,lv):
+        """ Construct a TPC. Each TPC includes the gas volume,
+            a field cage, and a readout plane.
 
+        Args:
+
+            geom: The geometry.
+            name: The name of the TPC. Should be unique.
+            pos_vec: A unit vector giving the direction about
+                     which the TPC should be translated. 
+                     Array-like.
+            rot: A rotation vector. Array-like
+            lv: The parent volume.
+
+        """
         # First, set up the main rotation and position to be used for the TPC
         tpc_rot = geom.structure.Rotation(name+'_rot',rot[0],rot[1],rot[2])
         pos = [ x*(self.HalfZ + self.TPCGap) for x in pos_vec]
@@ -237,10 +368,23 @@ class GArTPCBuilder(gegede.builder.Builder):
         self.construct_fieldcage(geom,name,tpc_pos,tpc_rot,lv)
 
     def construct_readout_plane(self,geom,name,pos_vec,tpc_rot,lv):
+        """ Construct a readout plane.
 
-        # Pad & Backing material in readout plane
-        # From ALICE TPC paper, ~5 mm thick total. We'll make it of FR4 here
-        # Offset 9 mm from TPC active volume due to wire grids (gating, cathode, anode)
+        This creates a PCB volume which holds the readout pads and
+        a support structure (modeled just as a box in this simplified
+        geometry). Wires, readout pad electrodes, and support structures
+        such as posts to hold wires or edges of readout regions are not
+        modeled. Based on ALICE TPC specs.
+
+        Args:
+            geom: The geometry.
+            name: The name of the TPC.
+            pos_vec: A unit vector pointing in the direction which this
+                     should be moved from the center. Array-like.
+            tpc_rot: The rotation for this TPC. A Rotation object. 
+            lv: The parent volume.
+
+        """
         padpos = [x*(self.TPCGap+2*self.HalfZ+self.PadOffset
                   +self.PadThickness/2) for x in pos_vec]
         pad_pos = geom.structure.Position(name+'pad_pos',
@@ -287,44 +431,58 @@ class GArTPCBuilder(gegede.builder.Builder):
         lv.placements.append(padframe_pla.name)
 
     def construct_fieldcage(self,geom,name,tpc_pos,tpc_rot,lv):
-        # Field cage pieces
+        """ Construct the field cage for a TPC.
 
-        # Based on ALICE design for now
+        Currently constructs the support structures for the field 
+        cage. This is based on the ALICE TPC design. The field cage
+        structure consists of a central honeycomb structure 
+        surrounded on both sides by kevlar and then tedlar.
+
+        Field cage posts and conductive strips are not currently 
+        modeled.
  
+        Args:
+            geom: The geometry 
+            name: The name of the TPC
+            tpc_pos: The position of the TPC center. A Position object.
+            tpc_rot: The rotation of this TPC. A Rotation object. 
+            lv: The parent volume.
+
+        """
         # Outer Tedlar layers
         fc_dx = Q('31.3mm')
         fc_out_x = self.HalfX + fc_dx + self.SmallGap
         fc_out_y = self.HalfY + fc_dx + self.SmallGap
         fc_in_x = self.HalfX + self.SmallGap
         fc_in_y = self.HalfY + self.SmallGap
-        pvf_dx = Q('0.05mm')
+        cvf_dx = Q('0.05mm')
 
-        fc_pvf_1 = geom.shapes.Box(name+'fc_pvf1_shape',
+        fc_cvf_1 = geom.shapes.Box(name+'fc_cvf1_shape',
                                    fc_out_x,fc_out_y,self.HalfZ)
-        fc_pvf_0 = geom.shapes.Box(name+'fc_pvf0_shape',
+        fc_cvf_0 = geom.shapes.Box(name+'fc_cvf0_shape',
                                    fc_in_x,fc_in_y,self.HalfZ+Q('1mm'))
-        fc_pvf_shape = geom.shapes.Boolean(name+'fc_pvf_shape',
+        fc_cvf_shape = geom.shapes.Boolean(name+'fc_cvf_shape',
                                            type='subtraction',
-                                           first=fc_pvf_1,
-                                           second=fc_pvf_0)
-        fc_pvf_lv = geom.structure.Volume(name+'fc_pvf_vol',
-                                          material='PVF',
-                                          shape=fc_pvf_shape)
-        fc_pvf_pla = geom.structure.Placement(name+'fc_pvf_pla',
-                                             volume=fc_pvf_lv,
+                                           first=fc_cvf_1,
+                                           second=fc_cvf_0)
+        fc_cvf_lv = geom.structure.Volume(name+'fc_cvf_vol',
+                                          material='CVF',
+                                          shape=fc_cvf_shape)
+        fc_cvf_pla = geom.structure.Placement(name+'fc_cvf_pla',
+                                             volume=fc_cvf_lv,
                                              pos=tpc_pos,
                                              rot=tpc_rot)
-        lv.placements.append(fc_pvf_pla.name)
+        lv.placements.append(fc_cvf_pla.name)
 
         # Kevlar Prepreg (Kevlar/epoxy mixture) layers
         kev_dx = Q('0.6mm')
         fc_kev_1 = geom.shapes.Box(name+'fc_kev1_shape',
-                                   fc_out_x-pvf_dx,
-                                   fc_out_y-pvf_dx,
+                                   fc_out_x-cvf_dx,
+                                   fc_out_y-cvf_dx,
                                    self.HalfZ-2*self.SmallGap)
         fc_kev_0 = geom.shapes.Box(name+'fc_kev0_shape',
-                                   fc_in_x+pvf_dx,
-                                   fc_in_y+pvf_dx,
+                                   fc_in_x+cvf_dx,
+                                   fc_in_y+cvf_dx,
                                    self.HalfZ-self.SmallGap)
         fc_kev_shape = geom.shapes.Boolean(name+'fc_kev_shape',
                                            type='subtraction', 
@@ -335,16 +493,16 @@ class GArTPCBuilder(gegede.builder.Builder):
                                           shape=fc_kev_shape)
         fc_kev_pla = geom.structure.Placement(name+'fc_kev_pla',
                                               volume=fc_kev_lv)
-        fc_pvf_lv.placements.append(fc_kev_pla.name)
+        fc_cvf_lv.placements.append(fc_kev_pla.name)
 
         # Nomex Honeycomb layer
         fc_hc_1 = geom.shapes.Box(name+'fc_hc1_shape',
-                                   fc_out_x-pvf_dx-kev_dx,
-                                   fc_out_y-pvf_dx-kev_dx,
+                                   fc_out_x-cvf_dx-kev_dx,
+                                   fc_out_y-cvf_dx-kev_dx,
                                    self.HalfZ-4*self.SmallGap)
         fc_hc_0 = geom.shapes.Box(name+'fc_hc0_shape',
-                                   fc_in_x+pvf_dx+kev_dx,
-                                   fc_in_y+pvf_dx+kev_dx,
+                                   fc_in_x+cvf_dx+kev_dx,
+                                   fc_in_y+cvf_dx+kev_dx,
                                    self.HalfZ-3*self.SmallGap)
         fc_hc_shape = geom.shapes.Boolean(name+'fc_hc_shape',
                                            type='subtraction',

--- a/duneggd/SubDetector/GArTPC.py
+++ b/duneggd/SubDetector/GArTPC.py
@@ -23,6 +23,13 @@ class GArTPCBuilder(gegede.builder.Builder):
         self.WallThickness = Q("1cm")
         self.ChamberMaterial = "Steel"
 
+        if "EndCapThickness" in kwargs.keys():
+            self.EndCapThickness = kwargs['EndCapThickness']
+        if 'WallThickness' in kwargs.keys():
+            self.WallThiciness = kwargs['WallThickness']
+        if 'ChamberMaterial' in kwargs.keys():
+            self.ChamberMaterial = kwargs['ChamberMaterial']
+
         # Should be a 3D array Quantity objects
         # Will support dipole and solenoid type fields
         # Really should be set with a magnet builder but here for testing
@@ -53,7 +60,26 @@ class GArTPCBuilder(gegede.builder.Builder):
         self.Drift = drift
         # A bit of space for the central electrode
         self.TPCGap = Q('2mm') 
+        self.SmallGap = Q('0.001mm')
 
+        # Readout Pad Stuff
+
+        self.PadThickness = Q('5mm')
+        self.PadMaterial = 'FR4'
+        self.PadOffset = Q('9mm')
+        self.PadFrameThickness = Q('1.5cm')
+        self.PadFrameMaterial = 'Aluminum'
+
+        if 'PadThickness' in kwargs.keys():
+            self.PadThickness = kwargs['PadThickness']
+        if 'PadMaterial' in kwargs.keys():
+            self.PadMaterial = kwargs['PadMaterial']
+        if 'PadFrameThickness' in kwargs.keys():
+            self.PadFrameThickness = kwargs['PadFrameThickness']
+        if 'PadFrameMaterial' in kwargs.keys():
+            self.PadFrameMaterial = kwargs['PadFrameMaterial']
+        if 'PadOffset' in kwargs.keys():
+            self.PadOffset = kwargs['PadOffset']
 
     def construct(self,geom):
 
@@ -74,7 +100,8 @@ class GArTPCBuilder(gegede.builder.Builder):
                                                material=self.ChamberMaterial,
                                                shape=tpc_chamber_shape)
 
-
+        if self.BField is not None:
+            tpc_chamber_lv.params.append(('BField',self.BField))
         # Place into main LV
         pos = [Q('0m'),Q('0m'),Q('0m')]
         tpc_chamber_pos = geom.structure.Position('TPCChamber_pos',
@@ -136,10 +163,50 @@ class GArTPCBuilder(gegede.builder.Builder):
             rot1 = [Q('0deg'),Q('0deg'),Q('0deg')]
             rot2 = [Q('180deg'),Q('0deg'),Q('0deg')]
 
-
+        self.construct_central_electrode(geom,rot1,lv)
         self.construct_tpc(geom,"TPC1",pos1,rot1,lv)
         self.construct_tpc(geom,"TPC2",pos2,rot2,lv)
 
+    def construct_central_electrode(self,geom,rot,lv):
+        
+        # Create the shape and logical volume
+        cent_hc_dx = Q('6mm')
+        cent_my_dx = Q('0.02mm')
+        cent_elec_shape = geom.shapes.Box('cent_elec_shape',
+                                          self.HalfX,
+                                          self.HalfY,
+                                          cent_hc_dx/2+cent_my_dx)
+        cent_elec_lv = geom.structure.Volume('cent_elec_vol',material = 'Mylar',
+                                       shape=cent_elec_shape)
+
+        elec_rot = geom.structure.Rotation('cent_elec_rot',rot[0],rot[1],rot[2])
+        # Create a placement
+        cent_elec_pla = geom.structure.Placement('cent_elec_pla',
+                                            volume=cent_elec_lv,
+                                            rot=elec_rot
+                                           )
+
+        lv.placements.append(cent_elec_pla.name)
+
+        # The honeycomb structure
+
+        cent_hc_shape = geom.shapes.Box('cent_hc_shape',
+                                          self.HalfX-self.SmallGap,
+                                          self.HalfY-self.SmallGap,
+                                          cent_hc_dx/2)
+        cent_hc_lv = geom.structure.Volume('cent_hc_vol',material = 'NomexHoneycomb',
+                                       shape=cent_hc_shape)
+
+        elec_rot = geom.structure.Rotation('cent_hc_rot',rot[0],rot[1],rot[2])
+        # Create a placement
+        cent_hc_pla = geom.structure.Placement('cent_hc_pla',
+                                            volume=cent_hc_lv,
+                                            rot=elec_rot
+                                           )
+
+        cent_elec_lv.placements.append(cent_hc_pla.name)
+ 
+        self.TPCGap = cent_hc_dx/2+cent_my_dx+self.SmallGap
 
     def construct_tpc(self,geom,name,pos_vec,rot,lv):
 
@@ -166,4 +233,126 @@ class GArTPCBuilder(gegede.builder.Builder):
         # Place in the main gas volume
         lv.placements.append(tpc_pla.name)
 
-       
+        self.construct_readout_plane(geom,name,pos_vec,tpc_rot,lv)
+        self.construct_fieldcage(geom,name,tpc_pos,tpc_rot,lv)
+
+    def construct_readout_plane(self,geom,name,pos_vec,tpc_rot,lv):
+
+        # Pad & Backing material in readout plane
+        # From ALICE TPC paper, ~5 mm thick total. We'll make it of FR4 here
+        # Offset 9 mm from TPC active volume due to wire grids (gating, cathode, anode)
+        padpos = [x*(self.TPCGap+2*self.HalfZ+self.PadOffset
+                  +self.PadThickness/2) for x in pos_vec]
+        pad_pos = geom.structure.Position(name+'pad_pos',
+                                          padpos[0],
+                                          padpos[1],
+                                          padpos[2])
+
+        pad_shape = geom.shapes.Box(name+'pad_shape',
+                                    self.HalfX,
+                                    self.HalfY,
+                                    self.PadThickness/2)
+        pad_lv = geom.structure.Volume(name+'pad_vol',
+                                       material=self.PadMaterial,
+                                       shape=pad_shape)
+        pad_pla = geom.structure.Placement(name+'pad_pla',volume=pad_lv,
+                                           pos=pad_pos,
+                                           rot=tpc_rot)
+
+        lv.placements.append(pad_pla.name)
+
+        
+ 
+        # Pad support frame
+        padframepos = [padpos[x] + pos_vec[x]*(self.SmallGap
+                       +self.PadFrameThickness/2) for x in range(3)]
+
+        padframe_pos = geom.structure.Position(name+'padframe_pos',
+                                               padpos[0],
+                                               padpos[1],
+                                               padpos[2])
+
+        padframe_shape = geom.shapes.Box(name+'padframe_shape',
+                                         self.HalfX,
+                                         self.HalfY,
+                                         self.PadFrameThickness/2)
+        padframe_lv = geom.structure.Volume(name+'padframe_vol',
+                                            material=self.PadFrameMaterial,
+                                            shape=padframe_shape)
+        padframe_pla = geom.structure.Placement(name+'padframe_pla',
+                                                volume=padframe_lv,
+                                                pos=padframe_pos,
+                                                rot=tpc_rot)
+
+        lv.placements.append(padframe_pla.name)
+
+    def construct_fieldcage(self,geom,name,tpc_pos,tpc_rot,lv):
+        # Field cage pieces
+
+        # Based on ALICE design for now
+ 
+        # Outer Tedlar layers
+        fc_dx = Q('31.3mm')
+        fc_out_x = self.HalfX + fc_dx + self.SmallGap
+        fc_out_y = self.HalfY + fc_dx + self.SmallGap
+        fc_in_x = self.HalfX + self.SmallGap
+        fc_in_y = self.HalfY + self.SmallGap
+        pvf_dx = Q('0.05mm')
+
+        fc_pvf_1 = geom.shapes.Box(name+'fc_pvf1_shape',
+                                   fc_out_x,fc_out_y,self.HalfZ)
+        fc_pvf_0 = geom.shapes.Box(name+'fc_pvf0_shape',
+                                   fc_in_x,fc_in_y,self.HalfZ+Q('1mm'))
+        fc_pvf_shape = geom.shapes.Boolean(name+'fc_pvf_shape',
+                                           type='subtraction',
+                                           first=fc_pvf_1,
+                                           second=fc_pvf_0)
+        fc_pvf_lv = geom.structure.Volume(name+'fc_pvf_vol',
+                                          material='PVF',
+                                          shape=fc_pvf_shape)
+        fc_pvf_pla = geom.structure.Placement(name+'fc_pvf_pla',
+                                             volume=fc_pvf_lv,
+                                             pos=tpc_pos,
+                                             rot=tpc_rot)
+        lv.placements.append(fc_pvf_pla.name)
+
+        # Kevlar Prepreg (Kevlar/epoxy mixture) layers
+        kev_dx = Q('0.6mm')
+        fc_kev_1 = geom.shapes.Box(name+'fc_kev1_shape',
+                                   fc_out_x-pvf_dx,
+                                   fc_out_y-pvf_dx,
+                                   self.HalfZ-2*self.SmallGap)
+        fc_kev_0 = geom.shapes.Box(name+'fc_kev0_shape',
+                                   fc_in_x+pvf_dx,
+                                   fc_in_y+pvf_dx,
+                                   self.HalfZ-self.SmallGap)
+        fc_kev_shape = geom.shapes.Boolean(name+'fc_kev_shape',
+                                           type='subtraction', 
+                                           first=fc_kev_1,
+                                           second=fc_kev_0)
+        fc_kev_lv = geom.structure.Volume(name+'fc_kev_vol',
+                                          material='KevlarPrepreg',
+                                          shape=fc_kev_shape)
+        fc_kev_pla = geom.structure.Placement(name+'fc_kev_pla',
+                                              volume=fc_kev_lv)
+        fc_pvf_lv.placements.append(fc_kev_pla.name)
+
+        # Nomex Honeycomb layer
+        fc_hc_1 = geom.shapes.Box(name+'fc_hc1_shape',
+                                   fc_out_x-pvf_dx-kev_dx,
+                                   fc_out_y-pvf_dx-kev_dx,
+                                   self.HalfZ-4*self.SmallGap)
+        fc_hc_0 = geom.shapes.Box(name+'fc_hc0_shape',
+                                   fc_in_x+pvf_dx+kev_dx,
+                                   fc_in_y+pvf_dx+kev_dx,
+                                   self.HalfZ-3*self.SmallGap)
+        fc_hc_shape = geom.shapes.Boolean(name+'fc_hc_shape',
+                                           type='subtraction',
+                                           first=fc_hc_1,
+                                           second=fc_hc_0)
+        fc_hc_lv = geom.structure.Volume(name+'fc_hc_vol',
+                                          material='NomexHoneycomb',
+                                          shape=fc_hc_shape)
+        fc_hc_pla = geom.structure.Placement(name+'fc_hc_pla',
+                                              volume=fc_hc_lv)
+        fc_kev_lv.placements.append(fc_hc_pla.name)

--- a/duneggd/SubDetector/GArTPC.py
+++ b/duneggd/SubDetector/GArTPC.py
@@ -68,7 +68,7 @@ class GArTPCBuilder(gegede.builder.Builder):
                 tpcDimension: Dimensions of each TPC.
                     Dict with keys 'dx','dy','dz'
                 halfDimension: Half-dimensions of bounding volume.
-                    Dict with keys 'r' and 'dz' (dz=half of length)
+                    Dict with keys 'rmin', 'rmax' and 'dz' (dz=half of length)
                 Material: Gas material. String if using a standard
                     material, dict in the form {material:mass_fraction,...}
                 bfield: Magnetic field (3D array-like). Don't use if a
@@ -105,7 +105,7 @@ class GArTPCBuilder(gegede.builder.Builder):
         self.BField = bfield
         
         # The gas
-        if type(Material)=='string':
+        if type(Material)==str:
             # Set from a pre-defined material
             self.Material = Material
             self.GasDensity = None
@@ -450,7 +450,7 @@ class GArTPCBuilder(gegede.builder.Builder):
 
         """
         # Outer Tedlar layers
-        fc_dx = Q('31.3mm')
+        fc_dx = Q('21.3mm')
         fc_out_x = self.HalfX + fc_dx + self.SmallGap
         fc_out_y = self.HalfY + fc_dx + self.SmallGap
         fc_in_x = self.HalfX + self.SmallGap

--- a/duneggd/SubDetector/GArTPC.py
+++ b/duneggd/SubDetector/GArTPC.py
@@ -179,7 +179,7 @@ class GArTPCBuilder(gegede.builder.Builder):
 
         main_lv, main_hDim = ltools.main_lv(self,geom,'Tubs')
         print('GasTPCBuilder::construct()')
-        print('main_lv = ',main_lv.name)
+        print('main_lv = '+main_lv.name)
         self.add_volume(main_lv)
 
         # Construct the chamber

--- a/duneggd/SubDetector/KLOE.py
+++ b/duneggd/SubDetector/KLOE.py
@@ -55,15 +55,15 @@ class KLOEBuilder(gegede.builder.Builder):
     #^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^
     def construct(self, geom):
         main_lv, main_hDim = ltools.main_lv( self, geom, "Box")
-        print "KLOEBuilder::construct()"
-        print "main_lv = ", main_lv.name
+        print( "KLOEBuilder::construct()")
+        print( "main_lv = ", main_lv.name)
         self.add_volume( main_lv )
         self.build_yoke(main_lv,geom)
         self.build_solenoid(main_lv,geom)
         self.build_ecal(main_lv,geom)
         self.build_tracker(main_lv,geom)
         self.build_muon_system(main_lv,geom)
-        print "printing main_lv: ", main_lv
+        print( "printing main_lv: ", main_lv)
             
             
 #        TranspV = [0,0,1]
@@ -73,21 +73,21 @@ class KLOEBuilder(gegede.builder.Builder):
 
 #        pos = [Q('0m'),Q('0m'),-main_hDim[2]]
         pos = [Q('0m'),Q('0m'),Q('0m')]
-#        print "KLOE subbuilders"
+#        print( "KLOE subbuilders")
 #        for i,sb in enumerate(self.get_builders()):
 #            sb_lv = sb.get_volume()
-#            print "Working on ", i, sb_lv.name
+#            print( "Working on ", i, sb_lv.name)
 #            sb_dim = ltools.getShapeDimensions( sb_lv, geom )
 
 #            pos[2] = pos[2] + sb_dim[2] + self.InsideGap[i]
             # defining position, placement, and finally insert into main logic volume.
 #            pos_name=self.name+sb_lv.name+'_pos_'+str(i)
 #            pla_name=self.name+sb_lv.name+'_pla_'+str(i)
-#            print "Position name", pos_name
-#            print "Placement name", pla_name
+#            print( "Position name", pos_name)
+#            print( "Placement name", pla_name)
 #            sb_pos = geom.structure.Position(pos_name,pos[0], pos[1], pos[2])
 #            sb_pla = geom.structure.Placement(pla_name,volume=sb_lv, pos=sb_pos)
-#            print "Appending ",sb_pla.name," to main_lv=",main_lv.name
+#            print( "Appending ",sb_pla.name," to main_lv=",main_lv.name)
 #            main_lv.placements.append(sb_pla.name)
     
     def build_yoke(self,main_lv,geom):
@@ -105,7 +105,7 @@ class KLOEBuilder(gegede.builder.Builder):
         
 #        BField="(0.0 T, 0.0 T, %f T)"%(-BarrelBField/Q("1.0T"))
         BField="(- %f T, 0.0 T, 0.0 T)"%(-BarrelBField/Q("1.0T"))
-        print "Setting KLOE Barrel Bfield to ",BField
+        print( "Setting KLOE Barrel Bfield to ",BField)
         barrel_lv.params.append(("BField",BField))
 
 
@@ -115,7 +115,7 @@ class KLOEBuilder(gegede.builder.Builder):
         barrel_pla=geom.structure.Placement("KLOEYokeBarrel_pla",
                                             volume=barrel_lv,
                                             pos=barrel_pos)
-        print "appending ",barrel_pla.name
+        print( "appending ",barrel_pla.name)
         main_lv.placements.append(barrel_pla.name)
         
         # build endcap
@@ -146,7 +146,7 @@ class KLOEBuilder(gegede.builder.Builder):
                 ec_pla=geom.structure.Placement(name+"_pla",
                                                 volume=ec_lv,
                                                 pos=ec_pos)
-                print "appending ",ec_pla.name
+                print( "appending ",ec_pla.name)
                 main_lv.placements.append(ec_pla.name)
 
         
@@ -194,7 +194,7 @@ class KLOEBuilder(gegede.builder.Builder):
             ec_pla=geom.structure.Placement(name+"_pla",
                                             volume=ec_lv,
                                             pos=ec_pos)        
-            print "appending ",ec_pla.name
+            print( "appending ",ec_pla.name)
             main_lv.placements.append(ec_pla.name)
 
         # cryostat inner and outer walls
@@ -225,7 +225,7 @@ class KLOEBuilder(gegede.builder.Builder):
             pla=geom.structure.Placement(name+"_pla",
                                             volume=lv,
                                             pos=pos)        
-            print "appending ",pla.name
+            print( "appending ",pla.name)
             main_lv.placements.append(pla.name)
             
 
@@ -253,7 +253,7 @@ class KLOEBuilder(gegede.builder.Builder):
         pla=geom.structure.Placement(name+"_pla",
                                      volume=lv,
                                      pos=pos)        
-        print "appending ",pla.name
+        print( "appending ",pla.name)
         main_lv.placements.append(pla.name)
         
         
@@ -281,7 +281,7 @@ class KLOEBuilder(gegede.builder.Builder):
         pla=geom.structure.Placement(name+"_pla",
                                      volume=lv,
                                      pos=pos)        
-        print "appending ",pla.name
+        print( "appending ",pla.name)
         main_lv.placements.append(pla.name)
 
     def build_ecal(self,main_lv,geom):
@@ -327,7 +327,7 @@ class KLOEBuilder(gegede.builder.Builder):
             pla=geom.structure.Placement(name+"_pla",
                                          volume=lv,
                                          pos=pos)
-            print "appending ",pla.name
+            print( "appending ",pla.name)
             main_lv.placements.append(pla.name)
 
 
@@ -357,13 +357,13 @@ class KLOEBuilder(gegede.builder.Builder):
             pos[2]=KLOEEndcapECALStartZ+KLOEEndcapECALDepth/2.0
             if side=='L':
                 pos[2]=-pos[2]
-            print "pos[2]=",pos[2]
+            print( "pos[2]=",pos[2])
             pos=geom.structure.Position(name+"_pos",
                                         pos[0],pos[1], pos[2])
             pla=geom.structure.Placement(name+"_pla",
                                          volume=lv,
                                          pos=pos)
-            print "appending ",pla.name
+            print( "appending ",pla.name)
             main_lv.placements.append(pla.name)
 
     def build_tracker(self,main_lv,geom):
@@ -385,7 +385,7 @@ class KLOEBuilder(gegede.builder.Builder):
 
 #        BField="(0.0 T, 0.0 T, %f T)"%(self.CentralBField/Q("1.0T"))
         BField="(%f T, 0.0 T, 0.0 T)"%(self.CentralBField/Q("1.0T"))
-        print "Setting KLOE Central Tracker Bfield to ",BField
+        print( "Setting KLOE Central Tracker Bfield to ",BField)
         lv.params.append(("BField",BField))
         
         
@@ -411,7 +411,7 @@ class KLOEBuilder(gegede.builder.Builder):
         pla=geom.structure.Placement(name+"_pla",
                                      volume=lv,
                                      pos=pos)
-        print "appending ",pla.name
+        print( "appending ",pla.name)
 
         main_lv.placements.append(pla.name)
 

--- a/duneggd/SubDetector/KLOE.py
+++ b/duneggd/SubDetector/KLOE.py
@@ -56,14 +56,14 @@ class KLOEBuilder(gegede.builder.Builder):
     def construct(self, geom):
         main_lv, main_hDim = ltools.main_lv( self, geom, "Box")
         print( "KLOEBuilder::construct()")
-        print( "main_lv = ", main_lv.name)
+        print( "main_lv = "+ main_lv.name)
         self.add_volume( main_lv )
         self.build_yoke(main_lv,geom)
         self.build_solenoid(main_lv,geom)
         self.build_ecal(main_lv,geom)
         self.build_tracker(main_lv,geom)
         self.build_muon_system(main_lv,geom)
-        print( "printing main_lv: ", main_lv)
+        print( "printing main_lv: "+ str(main_lv))
             
             
 #        TranspV = [0,0,1]
@@ -105,7 +105,7 @@ class KLOEBuilder(gegede.builder.Builder):
         
 #        BField="(0.0 T, 0.0 T, %f T)"%(-BarrelBField/Q("1.0T"))
         BField="(- %f T, 0.0 T, 0.0 T)"%(-BarrelBField/Q("1.0T"))
-        print( "Setting KLOE Barrel Bfield to ",BField)
+        print( "Setting KLOE Barrel Bfield to "+str(BField))
         barrel_lv.params.append(("BField",BField))
 
 
@@ -115,7 +115,7 @@ class KLOEBuilder(gegede.builder.Builder):
         barrel_pla=geom.structure.Placement("KLOEYokeBarrel_pla",
                                             volume=barrel_lv,
                                             pos=barrel_pos)
-        print( "appending ",barrel_pla.name)
+        print( "appending "+barrel_pla.name)
         main_lv.placements.append(barrel_pla.name)
         
         # build endcap
@@ -146,7 +146,7 @@ class KLOEBuilder(gegede.builder.Builder):
                 ec_pla=geom.structure.Placement(name+"_pla",
                                                 volume=ec_lv,
                                                 pos=ec_pos)
-                print( "appending ",ec_pla.name)
+                print( "appending "+ec_pla.name)
                 main_lv.placements.append(ec_pla.name)
 
         
@@ -194,7 +194,7 @@ class KLOEBuilder(gegede.builder.Builder):
             ec_pla=geom.structure.Placement(name+"_pla",
                                             volume=ec_lv,
                                             pos=ec_pos)        
-            print( "appending ",ec_pla.name)
+            print( "appending "+ec_pla.name)
             main_lv.placements.append(ec_pla.name)
 
         # cryostat inner and outer walls
@@ -225,7 +225,7 @@ class KLOEBuilder(gegede.builder.Builder):
             pla=geom.structure.Placement(name+"_pla",
                                             volume=lv,
                                             pos=pos)        
-            print( "appending ",pla.name)
+            print( "appending "+pla.name)
             main_lv.placements.append(pla.name)
             
 
@@ -253,7 +253,7 @@ class KLOEBuilder(gegede.builder.Builder):
         pla=geom.structure.Placement(name+"_pla",
                                      volume=lv,
                                      pos=pos)        
-        print( "appending ",pla.name)
+        print( "appending "+pla.name)
         main_lv.placements.append(pla.name)
         
         
@@ -281,7 +281,7 @@ class KLOEBuilder(gegede.builder.Builder):
         pla=geom.structure.Placement(name+"_pla",
                                      volume=lv,
                                      pos=pos)        
-        print( "appending ",pla.name)
+        print( "appending "+pla.name)
         main_lv.placements.append(pla.name)
 
     def build_ecal(self,main_lv,geom):
@@ -327,7 +327,7 @@ class KLOEBuilder(gegede.builder.Builder):
             pla=geom.structure.Placement(name+"_pla",
                                          volume=lv,
                                          pos=pos)
-            print( "appending ",pla.name)
+            print( "appending "+pla.name)
             main_lv.placements.append(pla.name)
 
 
@@ -357,13 +357,13 @@ class KLOEBuilder(gegede.builder.Builder):
             pos[2]=KLOEEndcapECALStartZ+KLOEEndcapECALDepth/2.0
             if side=='L':
                 pos[2]=-pos[2]
-            print( "pos[2]=",pos[2])
+            print( "pos[2]="+str(pos[2]))
             pos=geom.structure.Position(name+"_pos",
                                         pos[0],pos[1], pos[2])
             pla=geom.structure.Placement(name+"_pla",
                                          volume=lv,
                                          pos=pos)
-            print( "appending ",pla.name)
+            print( "appending "+pla.name)
             main_lv.placements.append(pla.name)
 
     def build_tracker(self,main_lv,geom):
@@ -385,7 +385,7 @@ class KLOEBuilder(gegede.builder.Builder):
 
 #        BField="(0.0 T, 0.0 T, %f T)"%(self.CentralBField/Q("1.0T"))
         BField="(%f T, 0.0 T, 0.0 T)"%(self.CentralBField/Q("1.0T"))
-        print( "Setting KLOE Central Tracker Bfield to ",BField)
+        print( "Setting KLOE Central Tracker Bfield to "+str(BField))
         lv.params.append(("BField",BField))
         
         
@@ -411,7 +411,7 @@ class KLOEBuilder(gegede.builder.Builder):
         pla=geom.structure.Placement(name+"_pla",
                                      volume=lv,
                                      pos=pos)
-        print( "appending ",pla.name)
+        print( "appending "+pla.name)
 
         main_lv.placements.append(pla.name)
 

--- a/duneggd/SubDetector/KLOESTT.py
+++ b/duneggd/SubDetector/KLOESTT.py
@@ -21,7 +21,7 @@ class KLOESTTBuilder(gegede.builder.Builder):
         # main volume
         main_lv, main_hDim = ltools.main_lv( self, geom, "Box")
         print( "KLOESTT::construct()")
-        print( "  main_lv = ", main_lv.name)
+        print( "  main_lv = "+ main_lv.name)
         self.add_volume( main_lv )
         
         rot=[Q("90deg"),Q("0deg"),Q("0deg")]
@@ -36,7 +36,7 @@ class KLOESTTBuilder(gegede.builder.Builder):
         for imod in range(self.nModules):
             loc=[Q("0cm"),Q("0cm"),startz+(self.modWidth+self.gap)*(imod+0.5)]
             basename=self.name+'_'+mod_lv.name+'_'+str(imod)
-            print( "Placing STTModule",basename," at ",loc)
+            print( "Placing STTModule " + basename+" at "+str(loc))
             mod_pos=geom.structure.Position(basename+'_pos',loc[0],loc[1],loc[2])
             mod_rot=geom.structure.Rotation(basename+'_rot',rot[0],rot[1],rot[2])
             mod_pla=geom.structure.Placement(basename+'_pla',volume=mod_lv,pos=mod_pos,rot=mod_rot)

--- a/duneggd/SubDetector/KLOESTT.py
+++ b/duneggd/SubDetector/KLOESTT.py
@@ -20,8 +20,8 @@ class KLOESTTBuilder(gegede.builder.Builder):
     def construct( self, geom ):
         # main volume
         main_lv, main_hDim = ltools.main_lv( self, geom, "Box")
-        print "KLOESTT::construct()"
-        print "  main_lv = ", main_lv.name
+        print( "KLOESTT::construct()")
+        print( "  main_lv = ", main_lv.name)
         self.add_volume( main_lv )
         
         rot=[Q("90deg"),Q("0deg"),Q("0deg")]
@@ -36,7 +36,7 @@ class KLOESTTBuilder(gegede.builder.Builder):
         for imod in range(self.nModules):
             loc=[Q("0cm"),Q("0cm"),startz+(self.modWidth+self.gap)*(imod+0.5)]
             basename=self.name+'_'+mod_lv.name+'_'+str(imod)
-            print "Placing STTModule",basename," at ",loc
+            print( "Placing STTModule",basename," at ",loc)
             mod_pos=geom.structure.Position(basename+'_pos',loc[0],loc[1],loc[2])
             mod_rot=geom.structure.Rotation(basename+'_rot',rot[0],rot[1],rot[2])
             mod_pla=geom.structure.Placement(basename+'_pla',volume=mod_lv,pos=mod_pos,rot=mod_rot)

--- a/duneggd/SubDetector/Magnet.py
+++ b/duneggd/SubDetector/Magnet.py
@@ -58,9 +58,9 @@ class MagnetBuilder(gegede.builder.Builder):
 
 	self.MagnetInn = [(self.magInDim[0]+self.magGap)*self.nMag, self.magInDim[1], self.magInDim[2]]
 
-	print self.MagnetOutt[0]
-        print self.MagnetOutt[1]
-        print self.MagnetOutt[2]
+	print( self.MagnetOutt[0])
+        print( self.MagnetOutt[1])
+        print( self.MagnetOutt[2])
 
         magnetOut = geom.shapes.Box( 'MagnetOut',                 dx=0.5*self.magOutDimB[0],
                                   dy=0.5*self.magOutDimB[1],  dz=(self.magOutDimB[2]+self.magBGap)*self.nMag)

--- a/duneggd/SubDetector/MuIDBarrel.py
+++ b/duneggd/SubDetector/MuIDBarrel.py
@@ -32,7 +32,7 @@ class MuIDBarrelBuilder(gegede.builder.Builder):
         self.muidRot        = modMuidRot 
 	self.nMuTracker     = nMuTracker
         
-        #print self.builders
+        #print( self.builders)
         self.RPCTrayBldr = self.get_builder('RPCTray_End')
 	return
 
@@ -59,14 +59,14 @@ class MuIDBarrelBuilder(gegede.builder.Builder):
         # Steel Sheets: just leave the default material of volMuID* steel 
         #   and leave spaces instead of placing explicit volumes
 	
-        print 'Abs pos for '+ str(self.name) +' along Z: '+ str(self.muidAbsPos[2])
-	print math.cos(math.radians(60))
+        print( 'Abs pos for '+ str(self.name) +' along Z: '+ str(self.muidAbsPos[2]))
+	print( math.cos(math.radians(60)))
         EachAngle = int(360/self.nMuTracker)
 
  	#EachAngle = 0
 	for ii in range(self.nMuTracker):
 		Zrot         = Q('0deg')+EachAngle*ii*Q('1deg')
-		print 'rotating angle of '+str(ii)+' muon tracker: '+str(Zrot)
+		print( 'rotating angle of '+str(ii)+' muon tracker: '+str(Zrot))
 		#rAboutXZ     = geom.structure.Rotation( 'rAboutXZ'+str(ii), '0deg',  '0deg', -Zrot+Q('90deg')  )	
 		rAboutXZ     = geom.structure.Rotation( 'rAboutXZ'+str(ii),  Zrot-Q('0deg') , '0deg', '0deg'  )
         	for i in range(self.nPlanes):
@@ -76,7 +76,7 @@ class MuIDBarrelBuilder(gegede.builder.Builder):
                         xpos = self.muidDim[0] + self.muidAbsPos[0]
                         ypos = self.muidDim[1]*math.sin(Zrot) + self.muidAbsPos[1]
                         zpos = self.muidDim[1]*math.cos(Zrot) + self.muidAbsPos[2]
-			print 'position of tracker: '+str(xpos)+' '+str(ypos)+' '+str(zpos)
+			print( 'position of tracker: '+str(xpos)+' '+str(ypos)+' '+str(zpos))
             		for j in range(self.nTraysPerPlane):
 
                 		#xpos = -0.5*self.muidDim[0]+self.muidAbsPos[0]

--- a/duneggd/SubDetector/MuIDEnd.py
+++ b/duneggd/SubDetector/MuIDEnd.py
@@ -30,7 +30,7 @@ class MuIDEndBuilder(gegede.builder.Builder):
         self.nPlanes        = modNPlanes 
         self.muidRot        = modMuidRot 
         
-        #print self.builders
+        #print( self.builders)
         self.RPCTrayBldr = self.get_builder('RPCTray_End')
 	return
 
@@ -57,7 +57,7 @@ class MuIDEndBuilder(gegede.builder.Builder):
         # Steel Sheets: just leave the default material of volMuID* steel 
         #   and leave spaces instead of placing explicit volumes
 	
-        print 'Abs pos for '+ str(self.name) +' along Z: '+ str(self.muidAbsPos[2])
+        print( 'Abs pos for '+ str(self.name) +' along Z: '+ str(self.muidAbsPos[2]))
         
         for i in range(self.nPlanes):
             zpos = -0.5*self.muidDim[2]+(i+0.5)*rpcTrayDim[2]+i*self.steelPlateDim[2]+self.muidAbsPos[2]

--- a/duneggd/SubDetector/SimpleSubDetector.py
+++ b/duneggd/SubDetector/SimpleSubDetector.py
@@ -30,4 +30,4 @@ class SimpleSubDetectorBuilder(gegede.builder.Builder):
                 TranspV = self.TranspV
             ltools.placeBuilders( self, geom, main_lv, TranspV )
         else:
-            print "**Warning, no Elements to place inside ", self.name
+            print( "**Warning, no Elements to place inside ", self.name)

--- a/duneggd/SubDetector/SimpleSubDetector.py
+++ b/duneggd/SubDetector/SimpleSubDetector.py
@@ -30,4 +30,4 @@ class SimpleSubDetectorBuilder(gegede.builder.Builder):
                 TranspV = self.TranspV
             ltools.placeBuilders( self, geom, main_lv, TranspV )
         else:
-            print( "**Warning, no Elements to place inside ", self.name)
+            print( "**Warning, no Elements to place inside "+ self.name)


### PR DESCRIPTION
Tested on GArTPC and KLOE builders in python2.7 and python3.6.

In materialdefinition.py:

I added a bunch of materials for common gases and solid materials that could be used by gas TPCs. I also added several 10 atm gas mixes.

The molar mass of hydrogen had a typo (1.07 instead of 1.007)

Python3 Compatibility:
-I wrapped all print statements in parantheses and changed tuple prints to regular string prints so formatting looks good in both python versions. 
- In localtools.addAuxParams(), I changed the loop over iteritems() to a loop over keys. iteritems() and items() in python2 have now been merged into items() in python3, but python2 items() returns a list rather than an iterator. Looping over the dictionary will give the same behavior for both versions without needing a version check.
-I think GeGeDe might be more difficult to modify to work with both python3 and python2 without needing separate branches but it should be possible. 

For GArTPC:

I've added some code for field cage, readout plane, and central electrode material for the GArTPC. Now that this is done, I will look at reworking things to hopefully make it easier to write subbuilders or use existing ones.

I also added GArTPC class documentation and made some changes to the cfg files.